### PR TITLE
Fix missing MPI_Aint return type

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -66,7 +66,8 @@ pmpi_init_bindings = ["PMPI_INIT", "pmpi_init", "pmpi_init_", "pmpi_init__"]
 # In general, all MPI calls we care about return int.  We include double
 # to grab MPI_Wtick and MPI_Wtime, but we'll ignore the f2c and c2f calls
 # that return MPI_Datatypes and other such things.
-rtypes = ['int', 'double' ]
+# MPI_Aint_add and MPI_Aint_diff return MPI_Aint, so include that too. 
+rtypes = ['int', 'double', 'MPI_Aint' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
 exclude_strings = [ "c2f", "f2c", "typedef" ]


### PR DESCRIPTION
MPI's MPI_Aint_add and MPI_Aint_diff functions return MPI_Aint, so we need to include that in the return type list.