### PR TITLE
Some fixes for fortran-fixes branch

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -283,6 +283,14 @@ _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
 #define BufferC2F(x) (x)
 #endif /* defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__PGI) || defined(_CRAYC) */
 
+
+#ifndef WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_PREFIX
+#endif
+
+#ifndef WRAP_MPI_CALL_POSTFIX
+#define WRAP_MPI_CALL_POSTFIX
+#endif
 '''
 
 wrapper_main_pmpi_init_decls ='''
@@ -1018,17 +1026,23 @@ class FortranDelegation:
             out.write(mpich_call)
         else:
             out.write("#if (!defined(MPICH_HAS_C2F) && defined(MPICH_NAME) && (MPICH_NAME == 1)) /* MPICH test */\n")
+            out.write("WRAP_MPI_CALL_PREFIX\n")
             out.write(mpich_call)
+            out.write("WRAP_MPI_CALL_POSTFIX\n")
             out.write("#else /* MPI-2 safe call */\n")
             out.write(joinlines(self.temps))
             if mpich_c2f_call != mpi2_call:
                 out.write("# if defined(MPICH_NAME) && (MPICH_NAME == 1) /* MPICH test */\n")
                 out.write(joinlines(self.mpich_c2f_copies))
+                out.write("WRAP_MPI_CALL_PREFIX\n")
                 out.write(mpich_c2f_call)
+                out.write("WRAP_MPI_CALL_POSTFIX\n")
                 out.write(joinlines(self.mpich_c2f_writebacks))
                 out.write("# else /* MPI-2 safe call */\n")
             out.write(joinlines(self.copies))
+            out.write("WRAP_MPI_CALL_PREFIX\n")
             out.write(mpi2_call)
+            out.write("WRAP_MPI_CALL_POSTFIX\n")
             out.write(joinlines(self.writebacks))
             if mpich_c2f_call != mpi2_call:
                 out.write("# endif /* MPICH test */\n")

--- a/wrap.py
+++ b/wrap.py
@@ -74,7 +74,7 @@ pmpi_init_thread_bindings = ["PMPI_INIT_THREAD", "pmpi_init_thread", "pmpi_init_
 rtypes = ['int', 'double', 'MPI_Aint' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
-exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_" ]
+exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_", "MPI_Comm_spawn" ]
 
 # Regular expressions for start and end of declarations in mpi.h. These are
 # used to get the declaration strings out for parsing with formal_re below.

--- a/wrap.py
+++ b/wrap.py
@@ -114,13 +114,13 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(WRAP_DISABLE_MPI_DEPRECATION_WARNINGS)
 #define WRAP_MPI_CALL_PREFIX        \\
   _Pragma("clang diagnostic push"); \\
   _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 #define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && defined(WRAP_DISABLE_MPI_DEPRECATION_WARNINGS)
 #define WRAP_MPI_CALL_PREFIX      \\
   _Pragma("GCC diagnostic push"); \\
   _Pragma("GCC diagnostic ignored \\"-Wdeprecated-declarations\\"");

--- a/wrap.py
+++ b/wrap.py
@@ -284,12 +284,12 @@ _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
 #endif /* defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__PGI) || defined(_CRAYC) */
 
 
-#ifndef WRAP_MPI_CALL_PREFIX
-#define WRAP_MPI_CALL_PREFIX
-#endif
+#ifdef __clang__
+#define WRAP_MPI_CALL_PREFIX        \\
+  _Pragma("clang diagnostic push"); \\
+  _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 
-#ifndef WRAP_MPI_CALL_POSTFIX
-#define WRAP_MPI_CALL_POSTFIX
+#define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
 #endif
 '''
 
@@ -1250,7 +1250,10 @@ def write_fortran_wrappers(out, decl, return_val):
     if decl.hasArrayIndexOutputParam():
         call.addWriteback("}")
 
+    out.write("WRAP_MPI_CALL_PREFIX\n")
     call.write(out)
+    out.write("WRAP_MPI_CALL_POSTFIX\n")
+
     if decl.returnsErrorCode():
         out.write("    *ierr = %s;\n" % return_val)
     else:

--- a/wrap.py
+++ b/wrap.py
@@ -125,7 +125,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
-inline int __get_f_status_size(){int size; get_f_status_size(&size); return size}
+inline int __get_f_status_size(){int size; get_f_status_size(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -71,7 +71,7 @@ pmpi_init_thread_bindings = ["PMPI_INIT_THREAD", "pmpi_init_thread", "pmpi_init_
 # In general, all MPI calls we care about return int.  We include double
 # to grab MPI_Wtick and MPI_Wtime, but we'll ignore the f2c and c2f calls
 # that return MPI_Datatypes and other such things.
-rtypes = ['int', 'double' ]
+rtypes = ['int', 'double', 'MPI_Aint' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
 exclude_strings = [ "c2f", "f2c", "typedef" ]

--- a/wrap.py
+++ b/wrap.py
@@ -1188,10 +1188,10 @@ def write_fortran_wrappers(out, decl, return_val):
             elif not arg.isHandle():
                 # Non-MPI handle pointer types can be passed w/o dereferencing, but need to
                 # cast to correct pointer type first (from MPI_Fint*).
-                #if arg.isVoid():
+                if arg.isVoid():
                     call.addActual("BufferC2F((%s)%s)" % (arg.castType(), arg.name))
-                #else:
-                    #call.addActual("((%s)%s)" % (arg.castType(), arg.name))
+                else:
+                    call.addActual("((%s)%s)" % (arg.castType(), arg.name))
             else:
                 # For MPI-1, assume ints, cross fingers, and pass things straight through.
                 call.addActualMPICH("(%s*)%s" % (arg.type, arg.name))

--- a/wrap.py
+++ b/wrap.py
@@ -126,7 +126,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
 void get_mpi_f_status_size___(int*);
-inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
+static inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -125,7 +125,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
-inline int __get_f_status_size(){int size; get_f_status_size(&size); return size;}
+inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -114,12 +114,18 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
-#ifdef __clang__
+#if defined(__clang__)
 #define WRAP_MPI_CALL_PREFIX        \\
   _Pragma("clang diagnostic push"); \\
   _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
-
 #define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+
+#elif defined(__GNUC__)
+#define WRAP_MPI_CALL_PREFIX      \\
+  _Pragma("GCC diagnostic push"); \\
+  _Pragma("GCC diagnostic ignored \\"-Wdeprecated-declarations\\"");
+#define WRAP_MPI_CALL_POSTFIX _Pragma("GCC diagnostic pop");
+
 #else
 #define WRAP_MPI_CALL_PREFIX
 #define WRAP_MPI_CALL_POSTFIX

--- a/wrap.py
+++ b/wrap.py
@@ -74,7 +74,7 @@ pmpi_init_thread_bindings = ["PMPI_INIT_THREAD", "pmpi_init_thread", "pmpi_init_
 rtypes = ['int', 'double', 'MPI_Aint' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
-exclude_strings = [ "c2f", "f2c", "typedef" ]
+exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_" ]
 
 # Regular expressions for start and end of declarations in mpi.h. These are
 # used to get the declaration strings out for parsing with formal_re below.

--- a/wrap.py
+++ b/wrap.py
@@ -219,25 +219,25 @@ _EXTERN_C_ void *MPI_F_MPI_BOTTOM WEAK_POSTFIX;
 _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
 
 /* MPICH 2 requires no special handling - MPI_BOTTOM may (must!) be passed through as-is. */
-#define IsBottom(x) ((x) == (void *) &mpi_fortran_bottom || \
-                     (x) == (void *) &MPI_FORTRAN_BOTTOM || \
-                     (x) == (void *) &mpi_fortran_bottom_ || \
-                     (x) == (void *) &MPI_FORTRAN_BOTTOM_ || \
-                     (x) == (void *) &mpi_fortran_bottom__ || \
+#define IsBottom(x) ((x) == (void *) &mpi_fortran_bottom ||   \\
+                     (x) == (void *) &MPI_FORTRAN_BOTTOM ||   \\
+                     (x) == (void *) &mpi_fortran_bottom_ ||  \\
+                     (x) == (void *) &MPI_FORTRAN_BOTTOM_ ||  \\
+                     (x) == (void *) &mpi_fortran_bottom__ || \\
                      (x) == (void *) &MPI_FORTRAN_BOTTOM__)
-#define IsInPlace(x) ((x) == (void *) &mpi_fortran_in_place || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE || \
-                      (x) == (void *) &mpi_fortran_in_place_ || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE_ || \
-                      (x) == (void *) &mpi_fortran_in_place__ || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE__ || \
-                      (x) == (void *) &MPIFCMB4 || \
-                      (x) == (void *) &mpifcmb4 || \
-                      (x) == (void *) &MPIFCMB4_ || \
-                      (x) == (void *) &mpifcmb4_ || \
-                      (x) == (void *) &MPIFCMB4__ || \
-                      (x) == (void *) &mpifcmb4__ || \
-                      (x) == MPIR_F_MPI_IN_PLACE || \
+#define IsInPlace(x) ((x) == (void *) &mpi_fortran_in_place ||   \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE ||   \\
+                      (x) == (void *) &mpi_fortran_in_place_ ||  \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE_ ||  \\
+                      (x) == (void *) &mpi_fortran_in_place__ || \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE__ || \\
+                      (x) == (void *) &MPIFCMB4 ||               \\
+                      (x) == (void *) &mpifcmb4 ||               \\
+                      (x) == (void *) &MPIFCMB4_ ||              \\
+                      (x) == (void *) &mpifcmb4_ ||              \\
+                      (x) == (void *) &MPIFCMB4__ ||             \\
+                      (x) == (void *) &mpifcmb4__ ||             \\
+                      (x) == MPIR_F_MPI_IN_PLACE ||              \\
                       (x) == MPI_F_MPI_IN_PLACE)
 
 #ifdef USE_WEAK_PRAGMA

--- a/wrap.py
+++ b/wrap.py
@@ -125,6 +125,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
+void get_mpi_f_status_size___(int*);
 inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif

--- a/wrap.py
+++ b/wrap.py
@@ -290,6 +290,9 @@ _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
   _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 
 #define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+#else
+#define WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_POSTFIX
 #endif
 '''
 

--- a/wrap.py
+++ b/wrap.py
@@ -114,7 +114,16 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
+#ifdef __clang__
+#define WRAP_MPI_CALL_PREFIX        \\
+  _Pragma("clang diagnostic push"); \\
+  _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 
+#define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+#else
+#define WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_POSTFIX
+#endif
 '''
 
 fortran_wrapper_includes = '''
@@ -282,18 +291,6 @@ _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
 #else
 #define BufferC2F(x) (x)
 #endif /* defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__PGI) || defined(_CRAYC) */
-
-
-#ifdef __clang__
-#define WRAP_MPI_CALL_PREFIX        \\
-  _Pragma("clang diagnostic push"); \\
-  _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
-
-#define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
-#else
-#define WRAP_MPI_CALL_PREFIX
-#define WRAP_MPI_CALL_POSTFIX
-#endif
 '''
 
 wrapper_main_pmpi_init_decls ='''


### PR DESCRIPTION
We did some bug fixes to get wrap working with recent PnMPI development versions.

In addition to this I've introduced MPI call pre- and postflags to hide warnings about deprecated functions. This feature is required to be able to print deprecation warnings for the general code, but not for MPI functions, because old MPI functions must be wrapped, too.