### PR TITLE
Bugfixes for recent PnMPI

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -125,7 +125,8 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
-inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
+void get_mpi_f_status_size___(int*);
+static inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -125,7 +125,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
-inline int __get_f_status_size(){int size; get_f_status_size(&size); return size}
+inline int __get_f_status_size(){int size; get_f_status_size(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -1171,10 +1171,10 @@ def write_fortran_wrappers(out, decl, return_val):
             elif not arg.isHandle():
                 # Non-MPI handle pointer types can be passed w/o dereferencing, but need to
                 # cast to correct pointer type first (from MPI_Fint*).
-                #if arg.isVoid():
+                if arg.isVoid():
                     call.addActual("BufferC2F((%s)%s)" % (arg.castType(), arg.name))
-                #else:
-                    #call.addActual("((%s)%s)" % (arg.castType(), arg.name))
+                else:
+                    call.addActual("((%s)%s)" % (arg.castType(), arg.name))
             else:
                 # For MPI-1, assume ints, cross fingers, and pass things straight through.
                 call.addActualMPICH("(%s*)%s" % (arg.type, arg.name))

--- a/wrap.py
+++ b/wrap.py
@@ -125,7 +125,7 @@ _EXTERN_C_ void *MPIR_ToPointer(int);
 #if defined(MPI_STATUS_SIZE) && MPI_STATUS_SIZE > 0
 #define MPI_F_STATUS_SIZE MPI_STATUS_SIZE
 #else
-inline int __get_f_status_size(){int size; get_f_status_size(&size); return size;}
+inline int __get_f_status_size(){int size; get_mpi_f_status_size___(&size); return size;}
 #define MPI_F_STATUS_SIZE __get_f_status_size()
 #endif
 

--- a/wrap.py
+++ b/wrap.py
@@ -219,25 +219,25 @@ _EXTERN_C_ void *MPI_F_MPI_BOTTOM WEAK_POSTFIX;
 _EXTERN_C_ void *MPI_F_MPI_IN_PLACE WEAK_POSTFIX;
 
 /* MPICH 2 requires no special handling - MPI_BOTTOM may (must!) be passed through as-is. */
-#define IsBottom(x) ((x) == (void *) &mpi_fortran_bottom || \
-                     (x) == (void *) &MPI_FORTRAN_BOTTOM || \
-                     (x) == (void *) &mpi_fortran_bottom_ || \
-                     (x) == (void *) &MPI_FORTRAN_BOTTOM_ || \
-                     (x) == (void *) &mpi_fortran_bottom__ || \
+#define IsBottom(x) ((x) == (void *) &mpi_fortran_bottom ||   \\
+                     (x) == (void *) &MPI_FORTRAN_BOTTOM ||   \\
+                     (x) == (void *) &mpi_fortran_bottom_ ||  \\
+                     (x) == (void *) &MPI_FORTRAN_BOTTOM_ ||  \\
+                     (x) == (void *) &mpi_fortran_bottom__ || \\
                      (x) == (void *) &MPI_FORTRAN_BOTTOM__)
-#define IsInPlace(x) ((x) == (void *) &mpi_fortran_in_place || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE || \
-                      (x) == (void *) &mpi_fortran_in_place_ || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE_ || \
-                      (x) == (void *) &mpi_fortran_in_place__ || \
-                      (x) == (void *) &MPI_FORTRAN_IN_PLACE__ || \
-                      (x) == (void *) &MPIFCMB4 || \
-                      (x) == (void *) &mpifcmb4 || \
-                      (x) == (void *) &MPIFCMB4_ || \
-                      (x) == (void *) &mpifcmb4_ || \
-                      (x) == (void *) &MPIFCMB4__ || \
-                      (x) == (void *) &mpifcmb4__ || \
-                      (x) == MPIR_F_MPI_IN_PLACE || \
+#define IsInPlace(x) ((x) == (void *) &mpi_fortran_in_place ||   \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE ||   \\
+                      (x) == (void *) &mpi_fortran_in_place_ ||  \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE_ ||  \\
+                      (x) == (void *) &mpi_fortran_in_place__ || \\
+                      (x) == (void *) &MPI_FORTRAN_IN_PLACE__ || \\
+                      (x) == (void *) &MPIFCMB4 ||               \\
+                      (x) == (void *) &mpifcmb4 ||               \\
+                      (x) == (void *) &MPIFCMB4_ ||              \\
+                      (x) == (void *) &mpifcmb4_ ||              \\
+                      (x) == (void *) &MPIFCMB4__ ||             \\
+                      (x) == (void *) &mpifcmb4__ ||             \\
+                      (x) == MPIR_F_MPI_IN_PLACE ||              \\
                       (x) == MPI_F_MPI_IN_PLACE)
 
 #ifdef USE_WEAK_PRAGMA


### PR DESCRIPTION
- Added a missing semicolon and a forward declaration for `get_mpi_f_status_size___` to get `__get_f_status_size` working.
- Re-enabled an if-clause, to get rid of some compiler warnings.
* Fixed some newline escapes in the defines, so they won't be deleted by python.