### PR TITLE
Ignore deprecated warnings for MPI calls

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -114,13 +114,13 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(WRAP_DISABLE_MPI_DEPRECATION_WARNINGS)
 #define WRAP_MPI_CALL_PREFIX        \\
   _Pragma("clang diagnostic push"); \\
   _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 #define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && defined(WRAP_DISABLE_MPI_DEPRECATION_WARNINGS)
 #define WRAP_MPI_CALL_PREFIX      \\
   _Pragma("GCC diagnostic push"); \\
   _Pragma("GCC diagnostic ignored \\"-Wdeprecated-declarations\\"");

--- a/wrap.py
+++ b/wrap.py
@@ -114,7 +114,16 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
+#ifdef __clang__
+#define WRAP_MPI_CALL_PREFIX        \\
+  _Pragma("clang diagnostic push"); \\
+  _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
 
+#define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+#else
+#define WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_POSTFIX
+#endif
 '''
 
 fortran_wrapper_includes = '''
@@ -1017,17 +1026,23 @@ class FortranDelegation:
             out.write(mpich_call)
         else:
             out.write("#if (!defined(MPICH_HAS_C2F) && defined(MPICH_NAME) && (MPICH_NAME == 1)) /* MPICH test */\n")
+            out.write("WRAP_MPI_CALL_PREFIX\n")
             out.write(mpich_call)
+            out.write("WRAP_MPI_CALL_POSTFIX\n")
             out.write("#else /* MPI-2 safe call */\n")
             out.write(joinlines(self.temps))
             if mpich_c2f_call != mpi2_call:
                 out.write("# if defined(MPICH_NAME) && (MPICH_NAME == 1) /* MPICH test */\n")
                 out.write(joinlines(self.mpich_c2f_copies))
+                out.write("WRAP_MPI_CALL_PREFIX\n")
                 out.write(mpich_c2f_call)
+                out.write("WRAP_MPI_CALL_POSTFIX\n")
                 out.write(joinlines(self.mpich_c2f_writebacks))
                 out.write("# else /* MPI-2 safe call */\n")
             out.write(joinlines(self.copies))
+            out.write("WRAP_MPI_CALL_PREFIX\n")
             out.write(mpi2_call)
+            out.write("WRAP_MPI_CALL_POSTFIX\n")
             out.write(joinlines(self.writebacks))
             if mpich_c2f_call != mpi2_call:
                 out.write("# endif /* MPICH test */\n")
@@ -1235,7 +1250,10 @@ def write_fortran_wrappers(out, decl, return_val):
     if decl.hasArrayIndexOutputParam():
         call.addWriteback("}")
 
+    out.write("WRAP_MPI_CALL_PREFIX\n")
     call.write(out)
+    out.write("WRAP_MPI_CALL_POSTFIX\n")
+
     if decl.returnsErrorCode():
         out.write("    *ierr = %s;\n" % return_val)
     else:

--- a/wrap.py
+++ b/wrap.py
@@ -114,12 +114,18 @@ wrapper_includes = '''
 #endif /* _EXTERN_C_ */
 
 
-#ifdef __clang__
+#if defined(__clang__)
 #define WRAP_MPI_CALL_PREFIX        \\
   _Pragma("clang diagnostic push"); \\
   _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
-
 #define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+
+#elif defined(__GNUC__)
+#define WRAP_MPI_CALL_PREFIX      \\
+  _Pragma("GCC diagnostic push"); \\
+  _Pragma("GCC diagnostic ignored \\"-Wdeprecated-declarations\\"");
+#define WRAP_MPI_CALL_POSTFIX _Pragma("GCC diagnostic pop");
+
 #else
 #define WRAP_MPI_CALL_PREFIX
 #define WRAP_MPI_CALL_POSTFIX


### PR DESCRIPTION
Recent OpenMPI marks some functions as deprecated, but these functions should be wrapped, too. To be able to use the deprecated warnings feature of the compiler, the functionality introduced in this patch will disable the deprecation warnings for the MPI calls only, so you will see warnings for non-MPI functions only.

To disable the deprecation warnings for MPI calls in wrap generated code, simply add `-DWRAP_DISABLE_MPI_DEPRECATION_WARNINGS` to your compile flags. If your wrap template file contains PMPI calls, you may add the introduced pre- and post-flags around them:

``` C
WRAP_MPI_CALL_PREFIX
PMPI_Init(argc, argv);
WRAP_MPI_CALL_POSTFIX
```
