### PR TITLE
Added new excludes

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -69,7 +69,7 @@ pmpi_init_bindings = ["PMPI_INIT", "pmpi_init", "pmpi_init_", "pmpi_init__"]
 rtypes = ['int', 'double' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
-exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_" ]
+exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_", "MPI_Comm_spawn" ]
 
 # Regular expressions for start and end of declarations in mpi.h. These are
 # used to get the declaration strings out for parsing with formal_re below.

--- a/wrap.py
+++ b/wrap.py
@@ -69,7 +69,7 @@ pmpi_init_bindings = ["PMPI_INIT", "pmpi_init", "pmpi_init_", "pmpi_init__"]
 rtypes = ['int', 'double' ]
 
 # If we find these strings in a declaration, exclude it from consideration.
-exclude_strings = [ "c2f", "f2c", "typedef" ]
+exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_" ]
 
 # Regular expressions for start and end of declarations in mpi.h. These are
 # used to get the declaration strings out for parsing with formal_re below.


### PR DESCRIPTION
There have been issues with `MPI_T_*` and `MPI_Comm_spawn` functions. Thus it seems they don't have to be wrapped, they have been added to the exclude list.
