### PR TITLE
Added missing find_package for python interpreter.

### DIFF
--- a/WrapConfig.cmake
+++ b/WrapConfig.cmake
@@ -29,6 +29,7 @@ if (NOT Wrap_CONFIG_LOADED)
 
     # Play nice with FindPythonInterp -- use the interpreter if it was found,
     # otherwise use the script directly.
+    find_package(PythonInterp 2.6)
     if (PYTHON_EXECUTABLE)
       set(command ${PYTHON_EXECUTABLE})
       set(script_arg ${Wrap_EXECUTABLE})


### PR DESCRIPTION
The add_wrapped_file function in the CMake module for wrap does not search for
python, but wants to use it. At the moment this is done by PnMPI, but with
searching in wrap, packages depending on wrap don't have to take care about
the internals of wrap and its CMake functions anymore.
