### PR TITLE
Fix python3 compatibility bug

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -464,7 +464,7 @@ class Declaration:
         return self.argsNoEllipsis()[index].name
 
     def fortranFormals(self):
-        formals = map(Param.fortranFormal, self.argsNoEllipsis())
+        formals = list(map(Param.fortranFormal, self.argsNoEllipsis()))
         if self.name == "MPI_Init": formals = []    # Special case for init: no args in fortran
 
         ierr = []


### PR DESCRIPTION
Just a small fix to make formals a list, because later it is added to ierr, which is a list.

Without the fix I get following error message:

TypeError: unsupported operand type(s) for +: 'map' and 'list'
