### PR TITLE
Added option to suppress MPI deprecation warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ by Todd Gamblin, tgamblin@llnl.gov, https://github.com/tgamblin/wrap
                       automatically (use -DPIC when you compile dynamic
                       libs).
        -o file        Send output to a file instead of stdout.
+       -w             Do not print compiler warnings for deprecated MPI functions.
+                      This option will add macros around {{callfn}} to disable (and
+                      restore) the compilers diagnostic functions, if the compiler
+                      supports this functionality.
 
 
 Thanks to these people for their suggestions and contributions:
@@ -306,6 +310,50 @@ We don't disallow `{{fnall}}` or `{{fn}}` with `-s`, but If you used
 `{{fnall}}` here, each XML tag would have a C wrapper function around it,
 which is probably NOT what you want.
 
+
+-w: Disable MPI deprecation warnings
+----------------------------------------
+
+At the time of implementing this feature, many old MPI functions got declared
+deprecated in OpenMPI:
+
+```
+warning: 'PMPI_Type_extent' is deprecated: MPI_Type_extent is superseded by MPI_Type_get_extent in MPI-2.0 [-Wdeprecated-declarations]
+          PMPI_Type_extent(recvtype, &re);
+          ^
+```
+
+Even if these functions are deprecated, they may be wrapped for older
+applications, so these warnings may confuse the user. Even worse: warnings about
+deprecated non-MPI functions may be missed.
+
+With enabling the  `-w` option of wrap, macros will be added around `{{callfn}}`
+to disable the warnings for MPI calls. However, if you use `{{fn_name}}`,
+`{{args}}`, etc. for custom invocations, you may add `WRAP_MPI_CALL_PREFIX` and
+`WRAP_MPI_CALL_POSTFIX` around your MPI calls, to suppress deprecation warnings
+for these calls, too.
+
+**Note:** If the could should be compatible with and without this functionality
+enabled, you'll have to check if the macros are available.
+
+Example:
+```
+#ifndef WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_PREFIX
+#endif
+
+#ifndef WRAP_MPI_CALL_POSTFIX
+#define WRAP_MPI_CALL_POSTFIX
+#endif
+
+
+{{fnall fn_name MPI_Pcontrol}}
+    WRAP_MPI_CALL_PREFIX
+    return P{{fn_name}}({{args}});
+    WRAP_MPI_CALL_POSTFIX
+{{endfnall}}
+```
+--------------
 
 1. Anthony Chan, William Gropp and Weing Lusk.  *User's Guide for MPE:
 Extensions for MPI Programs*.  ANL/MCS-TM-ANL-98/xx.

--- a/wrap.py
+++ b/wrap.py
@@ -46,6 +46,10 @@ usage_string = \
                   Default is \'pmpi_init_\'.  Wrappers compiled for PIC will guess the
                   right binding automatically (use -DPIC when you compile dynamic libs).
    -o file        Send output to a file instead of stdout.
+   -w             Do not print compiler warnings for deprecated MPI functions.
+                  This option will add macros around {{callfn}} to disable (and
+                  restore) the compilers diagnostic functions, if the compiler
+                  supports this functionality.
 
  by Todd Gamblin, tgamblin@llnl.gov
 '''
@@ -59,6 +63,7 @@ output_fortran_wrappers = False    # Don't print fortran wrappers by default
 output_guards = False              # Don't print reentry guards by default
 skip_headers = False               # Skip header information and defines (for non-C output)
 dump_prototypes = False            # Just exit and dump MPI protos if false.
+ignore_deprecated = False          # Do not print compiler warnings for deprecated MPI functions
 
 # Possible legal bindings for the fortran version of PMPI_Init()
 pmpi_init_bindings = ["PMPI_INIT", "pmpi_init", "pmpi_init_", "pmpi_init__"]
@@ -126,6 +131,33 @@ _EXTERN_C_ void pmpi_init(MPI_Fint *ierr);
 _EXTERN_C_ void PMPI_INIT(MPI_Fint *ierr);
 _EXTERN_C_ void pmpi_init_(MPI_Fint *ierr);
 _EXTERN_C_ void pmpi_init__(MPI_Fint *ierr);
+
+'''
+
+# Macros used to suppress MPI deprecation warnings.
+wrapper_diagnosics_macros = '''
+/* Macros to enable and disable compiler warnings for deprecated functions.
+ * These macros will be used to silent warnings about deprecated MPI functions,
+ * as these should be wrapped, even if they are deprecated.
+ *
+ * Note: The macros support GCC and clang compilers only. For other compilers
+ *       just add similar macros for your compiler.
+ */
+#if (defined(__GNUC__) && !defined(__clang__)) && \\
+  ((__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4)
+#define  WRAP_MPI_CALL_PREFIX     \\
+  _Pragma("GCC diagnostic push"); \\
+  _Pragma("GCC diagnostic ignored \\"-Wdeprecated-declarations\\"");
+#define WRAP_MPI_CALL_POSTFIX _Pragma("GCC diagnostic pop");
+#elif defined(__clang__)
+#define  WRAP_MPI_CALL_PREFIX       \\
+  _Pragma("clang diagnostic push"); \\
+  _Pragma("clang diagnostic ignored \\"-Wdeprecated-declarations\\"");
+#define WRAP_MPI_CALL_POSTFIX _Pragma("clang diagnostic pop");
+#else
+#define WRAP_MPI_CALL_PREFIX
+#define WRAP_MPI_CALL_POSTFIX
+#endif
 
 '''
 
@@ -916,7 +948,11 @@ def fn(out, scope, args, children):
         fn_scope["ret_val"] = return_val
         fn_scope["returnVal"]  = fn_scope["ret_val"]  # deprecated name.
 
-        c_call = "%s = P%s(%s);" % (return_val, fn.name, ", ".join(fn.argNames()))
+        if ignore_deprecated:
+            c_call = "%s\n%s = P%s(%s);\n%s" % ("WRAP_MPI_CALL_PREFIX", return_val, fn.name, ", ".join(fn.argNames()), "WRAP_MPI_CALL_POSTFIX")
+        else:
+            c_call = "%s = P%s(%s);" % (return_val, fn.name, ", ".join(fn.argNames()))
+
         if fn_name == "MPI_Init" and output_fortran_wrappers:
             def callfn(out, scope, args, children):
                 # All this is to deal with fortran, since fortran's MPI_Init() function is different
@@ -1241,7 +1277,7 @@ output = sys.stdout
 output_filename = None
 
 try:
-    opts, args = getopt.gnu_getopt(sys.argv[1:], "fsgdc:o:i:I:")
+    opts, args = getopt.gnu_getopt(sys.argv[1:], "fsgdwc:o:i:I:")
 except getopt.GetoptError as err:
     sys.stderr.write(err + "\n")
     usage()
@@ -1251,6 +1287,7 @@ for opt, arg in opts:
     if opt == "-f": output_fortran_wrappers = True
     if opt == "-s": skip_headers = True
     if opt == "-g": output_guards = True
+    if opt == "-w": ignore_deprecated = True
     if opt == "-c": mpicc = arg
     if opt == "-o": output_filename = arg
     if opt == "-I":
@@ -1292,6 +1329,10 @@ try:
     if not skip_headers:
         output.write(wrapper_includes)
         if output_guards: output.write("static int in_wrapper = 0;\n")
+
+    # Print the macros for disabling MPI function deprecation warnings.
+    if ignore_deprecated:
+        output.write(wrapper_diagnosics_macros)
 
     # Parse each file listed on the command line and execute
     # it once it's parsed.


### PR DESCRIPTION
Recent OpenMPI marks some MPI functions as deprecated, but these functions should be wrapped, too.

A new option in wrap adds macros around all MPI calls generated by `{{callfn}}`. These macros will suppress the compilers warnings about deprecated MPI functions. This will ensure, that warnings about MPI calls will be suppressed, but "real" deprecation warnings will be shown.

At the moment GCC >= 4.6 and clang are supported only. If the used compiler is not compatible, this feature will be disabled automatically.