### PR TITLE
Introduced new macro fntype.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ delegation via `{{callfn}}`:
     {{endfnall}}
     ```
 
+* `fntype` iterates over all functions with a given argument argument type.
+
+    ```
+    {{fntype <iterator variable name> <type>}}
+      // code here
+    {{endfntype}}
+    ```
+
+    Example:
+    ```
+    {{fntype fn_name MPI_Comm}}
+      printf("Function with MPI_Comm called.\n");
+      {{callfn}}
+    {{endfntype}}
+    ```
+    ```
+    _EXTERN_C_ int PMPI_Comm_rank(MPI_Comm comm, int *rank);
+    _EXTERN_C_ int MPI_Comm_rank(MPI_Comm comm, int *rank) {
+      int _wrap_py_return_val = 0;
+
+      printf("Function with MPI_Comm called.\n");
+      _wrap_py_return_val = PMPI_Comm_rank(comm, rank);
+      return _wrap_py_return_val;
+    }
+    ```
+
 * `callfn` expands to the call of the function being profiled.
 
 * `foreachfn` and `forallfn` are the counterparts of `fn` and `fnall`, but they don't generate the

--- a/wrap.py
+++ b/wrap.py
@@ -1567,6 +1567,12 @@ def fnall(out, scope, args, children):
     args or syntax_error("Error: fnall requires function name argument.")
     fn(out, scope, [args[0]] + all_but(args[1:]), children)
 
+@macro("fntype", has_body=True)
+def fntype(out, scope, args, children):
+    """Iterate over all functions with a specific type and generate skeleton too."""
+    len(args) == 2 or syntax_error("Error: fntype requires function name argument.")
+    fn(out, scope, [args[0]] + [decl.name for decl in mpi_functions.itervalues() if args[1] in decl.types()], children)
+
 @macro("sub")
 def sub(out, scope, args, children):
     """{{sub <string> <regexp> <substitution>}}


### PR DESCRIPTION
The new fntype macro can be used to limit the generation of wrappers on MPI
functions with a specific type.