### PR TITLE
Fix python3.12 compatibility issues

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -80,21 +80,21 @@ exclude_strings = [ "c2f", "f2c", "typedef", "MPI_T_", "MPI_Comm_spawn" ]
 
 # Regular expressions for start and end of declarations in mpi.h. These are
 # used to get the declaration strings out for parsing with formal_re below.
-begin_decl_re = re.compile("(" + "|".join(rtypes) + ")\s+(MPI_\w+)\s*\(")
+begin_decl_re = re.compile("(" + "|".join(rtypes) + r")\s+(MPI_\w+)\s*\(")
 exclude_re =    re.compile("|".join(exclude_strings))
-end_decl_re =   re.compile("\).*\;")
+end_decl_re =   re.compile(r"\).*\;")
 
 # Regular Expression for splitting up args. Matching against this
 # returns three groups: type info, arg name, and array info
 formal_re = re.compile(
-    "\s*(" +                       # Start type
-    "(?:const)?\s*" +              # Initial const
-    "\w+"                          # Type name (note: doesn't handle 'long long', etc. right now)
-    ")\s*(" +                      # End type, begin pointers
-    "(?:\s*\*(?:\s*const)?)*" +    # Look for 0 or more pointers with optional 'const'
-    ")\s*"                         # End pointers
-    "(?:(\w+)\s*)?" +              # Argument name. Optional.
-     "(\[.*\])?\s*$"               # Array type.  Also optional. Works for multidimensions b/c it's greedy.
+    r"\s*(" +                       # Start type
+    r"(?:const)?\s*" +              # Initial const
+    r"\w+"                          # Type name (note: doesn't handle 'long long', etc. right now)
+    r")\s*(" +                      # End type, begin pointers
+    r"(?:\s*\*(?:\s*const)?)*" +    # Look for 0 or more pointers with optional 'const'
+    r")\s*"                         # End pointers
+    r"(?:(\w+)\s*)?" +              # Argument name. Optional.
+    r"(\[.*\])?\s*$"                # Array type.  Also optional. Works for multidimensions b/c it's greedy.
     )
 
 # Fortran wrapper suffix


### PR DESCRIPTION
Fix python3.12 warnings

```
(venv) rscohn1@jfcsa14:mpi> python3.11 /local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py /local/rscohn1/csa/mpi/tools/csa-trace/otf2.w > /loc\
al/rscohn1/csa/mpi/build/mpi_trace.h                                                                                                           
(venv) rscohn1@jfcsa14:mpi> python3.12 /local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py /local/rscohn1/csa/mpi/tools/csa-trace/otf2.w > /loc\
al/rscohn1/csa/mpi/build/mpi_trace.h                                                                                                           
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:83: SyntaxWarning: invalid escape sequence '\s'                                             
  begin_decl_re = re.compile("(" + "|".join(rtypes) + ")\s+(MPI_\w+)\s*\(")                                                                    
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:85: SyntaxWarning: invalid escape sequence '\)'                                             
  end_decl_re =   re.compile("\).*\;")                                                                                                         
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:90: SyntaxWarning: invalid escape sequence '\s'                                             
  "\s*(" +                       # Start type                                                                                                  
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:91: SyntaxWarning: invalid escape sequence '\s'                                             
  "(?:const)?\s*" +              # Initial const                                                                                               
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:92: SyntaxWarning: invalid escape sequence '\w'                                             
  "\w+"                          # Type name (note: doesn't handle 'long long', etc. right now)                                                
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:93: SyntaxWarning: invalid escape sequence '\s'                                             
  ")\s*(" +                      # End type, begin pointers                                                                                    
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:94: SyntaxWarning: invalid escape sequence '\s'                                             
  "(?:\s*\*(?:\s*const)?)*" +    # Look for 0 or more pointers with optional 'const'                                                           
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:95: SyntaxWarning: invalid escape sequence '\s'                                             
  ")\s*"                         # End pointers                                                                                                
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:96: SyntaxWarning: invalid escape sequence '\w'                                             
  "(?:(\w+)\s*)?" +              # Argument name. Optional.                                                                                    
/local/rscohn1/csa/mpi/build/wrap/src/wrap/wrap.py:97: SyntaxWarning: invalid escape sequence '\['                                             
  "(\[.*\])?\s*$"               # Array type.  Also optional. Works for multidimensions b/c it's greedy.                                       
(venv) rscohn1@jfcsa14:mpi>
```